### PR TITLE
Set min.insync.replicas on topic creation

### DIFF
--- a/check/setup.go
+++ b/check/setup.go
@@ -170,7 +170,8 @@ func (check *HealthCheck) createTopic(name string, forHealthCheck bool) (err err
 
 	if !exists {
 		topicConfig := `{"version":1,"config":{"delete.retention.ms":"10000",` +
-			`"cleanup.policy":"delete","compression.type":"uncompressed"}}`
+			`"cleanup.policy":"delete","compression.type":"uncompressed",` +
+			`"min.insync.replicas":"1"}}`
 		log.Infof(`creating topic "%s" configuration node`, name)
 
 		if err = createZkNode(zkConn, topicPath, topicConfig, forHealthCheck); err != nil {


### PR DESCRIPTION
On clusters with a default min.insync.replicas setting, the health
check failed as it does not properly set up the topic replica set for
the simple health checks. Setting min.insync.replicas explicitly to 1
on topic creation fixes this issue.

Resolves: #13