### PR TITLE
Supporting multiple brokers

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,34 +46,34 @@ information provided by kafka-health-check.
 
 ```
 kafka-health-check usage:
-  -broker-host string
-	ip address or hostname of broker host
+  -broker-hosts string
+  ip address or hostname of broker hosts, comma separated (e.g. broker1,broker2) without ports
   -broker-id uint
-    	id of the Kafka broker to health check (default 0)
+      id of the Kafka broker to health check (default 0)
   -broker-port uint
-    	Kafka broker port (default 9092)
+      Kafka broker port (default 9092). This port will be used for all brokers
   -check-interval duration
-    	how frequently to perform health checks (default 10s)
+      how frequently to perform health checks (default 10s)
   -no-topic-creation
-    	disable automatic topic creation and deletion
+      disable automatic topic creation and deletion
   -replication-failures-count uint
-    	number of replication failures before broker is reported unhealthy (default 5)
+      number of replication failures before broker is reported unhealthy (default 5)
   -replication-topic string
-    	name of the topic to use for replication checks - use one per cluster, defaults to broker-replication-check
+      name of the topic to use for replication checks - use one per cluster, defaults to broker-replication-check
   -server-port uint
-    	port to open for http health status queries (default 8000)
+      port to open for http health status queries (default 8000)
   -topic string
-    	name of the topic to use - use one per broker, defaults to broker-<id>-health-check
+      name of the topic to use - use one per broker, defaults to broker-<id>-health-check. In case of multiple brokers provide list of topics separated by comma 
   -zookeeper string
-    	ZooKeeper connect string (e.g. node1:2181,node2:2181,.../chroot)
+      ZooKeeper connect string (e.g. node1:2181,node2:2181,.../chroot)
 ```
 
 ## Broker Health
 
-Broker health can be queried at `/`:
+Broker health can be queried at `/{brokerid}`: brokerids are assinged in sequence
 
 ```
-$ curl -s <broker-host>:8000/
+$ curl -s <broker-host>:8000/0
 {"status":"sync"}
 ```
 
@@ -89,7 +89,7 @@ Return codes and status values are:
 The returned json contains details about replicas the broker is lagging behind:
 
 ```
-$ curl -s <broker-host>:8000/
+$ curl -s <broker-host>:8000/0
 {"status":"imok","out-of-sync":[{"topic":"mytopic","partition":0}],"replication-failures":1}
 ```
 

--- a/check/broker_health_check.go
+++ b/check/broker_health_check.go
@@ -11,6 +11,7 @@ import (
 
 // sends one message to the broker partition, wait for it to appear on the consumer.
 func (check *HealthCheck) checkBrokerHealth(metadata *proto.MetadataResp) BrokerStatus {
+
 	status := unhealthy
 	payload := randomBytes(check.config.MessageLength, check.randSrc)
 	message := &proto.Message{Value: []byte(payload)}
@@ -36,6 +37,9 @@ func (check *HealthCheck) waitForMessage(message *proto.Message) string {
 	deadline := time.Now().Add(check.config.CheckTimeout)
 	for time.Now().Before(deadline) {
 		receivedMessage, err := check.consumer.Consume()
+
+
+
 		if err != nil {
 			if err != kafka.ErrNoData {
 				log.Println("consumer failure - broker unhealthy:", err)
@@ -46,10 +50,15 @@ func (check *HealthCheck) waitForMessage(message *proto.Message) string {
 			}
 			continue
 		}
+		log.Println("receivedMessage .... " + string(receivedMessage.Value))
+		log.Println("producedMessage " + string(message.Value))
+
 		if string(receivedMessage.Value) == string(message.Value) {
+			log.Println("returning healthy....")
 			return healthy
 		}
 	}
+	log.Println("returning UNhealthy....")
 	return unhealthy
 }
 

--- a/check/parse_args.go
+++ b/check/parse_args.go
@@ -11,21 +11,19 @@ import (
 	logr "github.com/Sirupsen/logrus"
 )
 
-// ParseCommandLineArguments parses the command line arguments.
-func (check *HealthCheck) ParseCommandLineArguments() {
-	flag.StringVar(&check.config.brokerHost, "broker-host", "localhost", "ip address or hostname of broker host")
-	flag.UintVar(&check.config.brokerID, "broker-id", 0, "id of the Kafka broker to health check")
-	flag.UintVar(&check.config.brokerPort, "broker-port", 9092, "Kafka broker port")
-	flag.UintVar(&check.config.statusServerPort, "server-port", 8000, "port to open for http health status queries")
-	flag.StringVar(&check.config.zookeeperConnect, "zookeeper", "", "ZooKeeper connect string (e.g. node1:2181,node2:2181,.../chroot)")
-	flag.StringVar(&check.config.topicName, "topic", "", "name of the topic to use - use one per broker, defaults to broker-<id>-health-check")
-	flag.StringVar(&check.config.replicationTopicName, "replication-topic", "",
-		"name of the topic to use for replication checks - use one per cluster, defaults to broker-replication-check")
-	flag.UintVar(&check.config.replicationFailureThreshold, "replication-failures-count", 5,
-		"number of replication failures before broker is reported unhealthy")
-	flag.DurationVar(&check.config.CheckInterval, "check-interval", 10*time.Second, "how frequently to perform health checks")
-	flag.BoolVar(&check.config.NoTopicCreation, "no-topic-creation", false, "disable automatic topic creation and deletion")
-	flag.Parse()
+func (check *HealthCheck) ParseCommandLineArguments(brokerHost string,brokerID uint,brokerPort uint,statusServerPort uint,zookeeperConnect string,topicName string,replicationTopicName string,replicationFailureThreshold uint,CheckInterval time.Duration,NoTopicCreation bool){
+
+	check.config.brokerHost = brokerHost
+	check.config.brokerID = brokerID
+	check.config.brokerPort = brokerPort
+	check.config.statusServerPort = statusServerPort
+	check.config.zookeeperConnect = zookeeperConnect
+	check.config.topicName = topicName
+	check.config.replicationTopicName = replicationTopicName
+	check.config.replicationFailureThreshold = replicationFailureThreshold
+	check.config.CheckInterval = CheckInterval
+	check.config.NoTopicCreation = NoTopicCreation
+
 	l := log.New(os.Stderr, "", 0)
 	valid := check.validateConfig(l)
 	if !valid {

--- a/check/status_server.go
+++ b/check/status_server.go
@@ -2,17 +2,14 @@ package check
 
 import (
 	"bytes"
-	"fmt"
 	"io"
-	"net"
 	"net/http"
 
 	log "github.com/Sirupsen/logrus"
 )
 
 // ServeHealth answers http queries for broker and cluster health.
-func (check *HealthCheck) ServeHealth(brokerUpdates <-chan Update, clusterUpdates <-chan Update, stop <-chan struct{}) {
-	port := check.config.statusServerPort
+func (check *HealthCheck) ServeHealth(brokerUpdates <-chan Update, stop <-chan struct{},brokerID string) {
 
 	statusServer := func(name, path, errorStatus string, updates <-chan Update) {
 		requests := make(chan chan Update)
@@ -48,23 +45,53 @@ func (check *HealthCheck) ServeHealth(brokerUpdates <-chan Update, clusterUpdate
 		})
 	}
 
-	http.DefaultServeMux = http.NewServeMux()
-	statusServer("cluster", "/cluster", red, clusterUpdates)
-	statusServer("broker", "/", unhealthy, brokerUpdates)
-
-	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
-	if err != nil {
-		log.Fatal("Unable to listen to port ", port, ": ", err)
-	}
-
-	go func() {
-		for {
-			select {
-			case <-stop:
-				listener.Close()
-			}
-		}
-	}()
-	http.Serve(listener, nil)
+	statusServer("broker", "/" + brokerID, unhealthy, brokerUpdates)
+	log.Println("added " + "/" + brokerID)
+	
 	return
 }
+
+func (check *HealthCheck) ServeHealthCluster(clusterUpdates <-chan Update, stop <-chan struct{}) {
+
+	statusServer := func(name, path, errorStatus string, updates <-chan Update) {
+		requests := make(chan chan Update)
+
+		// goroutine that encapsulates the current status
+		go func() {
+			status := Update{errorStatus, simpleStatus(errorStatus)}
+			for {
+				select {
+				case update := <-updates:
+
+					if !bytes.Equal(status.Data, update.Data) {
+						log.WithField("status", string(update.Data)).Info(name, " now reported as ", update.Status)
+						status = update
+					}
+
+				case request := <-requests:
+					request <- status
+				}
+			}
+		}()
+
+		http.HandleFunc(path, func(writer http.ResponseWriter, request *http.Request) {
+			responseChannel := make(chan Update)
+			requests <- responseChannel
+			currentStatus := <-responseChannel
+			if currentStatus.Status == errorStatus {
+				http.Error(writer, string(currentStatus.Data), 500)
+			} else {
+				writer.Write(currentStatus.Data)
+				io.WriteString(writer, "\n")
+			}
+		})
+	}
+
+	
+	statusServer("cluster", "/cluster", red, clusterUpdates)
+	log.Println("added " + "/cluster")
+	
+	return
+}
+
+

--- a/main.go
+++ b/main.go
@@ -6,19 +6,148 @@ import (
 	"sync"
 	"syscall"
 	"time"
-
-	"github.com/andreas-schroeder/kafka-health-check/check"
+	"flag"
+	"github.com/ltnilaysahu/kafka-health-check/check"
+	"strings"
+	"net/http"
+	"fmt"
+	log "github.com/Sirupsen/logrus"
+	"net"
+	"strconv"
 )
 
 func main() {
-	healthCheck := check.New(checkConfiguration)
-	healthCheck.ParseCommandLineArguments()
 
-	stop, awaitCheck := addShutdownHook()
-	brokerUpdates, clusterUpdates := make(chan check.Update, 2), make(chan check.Update, 2)
-	go healthCheck.ServeHealth(brokerUpdates, clusterUpdates, stop)
-	healthCheck.CheckHealth(brokerUpdates, clusterUpdates, stop)
-	awaitCheck.Done()
+	var brokerHosts string
+	var zookeeperConnect string
+	var topics string
+	var replicationTopicName string
+	var replicationFailureThreshold uint
+	var CheckInterval time.Duration 
+	var NoTopicCreation bool
+	var statusServerPort uint
+	var brokerPort uint
+
+	flag.StringVar(&brokerHosts, "broker-hosts", "localhost", "ip address or hostname of broker host")
+	flag.UintVar(&brokerPort, "broker-port", 9092, "Kafka broker port")
+	flag.UintVar(&statusServerPort, "server-port", 8000, "port to open for http health status queries")
+	flag.StringVar(&zookeeperConnect, "zookeeper", "", "ZooKeeper connect string (e.g. node1:2181,node2:2181,.../chroot)")
+	flag.StringVar(&topics, "topic", "", "name of the topic to use - use one per broker, defaults to broker-<id>-health-check")
+	flag.StringVar(&replicationTopicName, "replication-topic", "",
+		"name of the topic to use for replication checks - use one per cluster, defaults to broker-replication-check")
+	flag.UintVar(&replicationFailureThreshold, "replication-failures-count", 5,
+		"number of replication failures before broker is reported unhealthy")
+	flag.DurationVar(&CheckInterval, "check-interval", 5*time.Second, "how frequently to perform health checks")
+	flag.BoolVar(&NoTopicCreation, "no-topic-creation", false, "disable automatic topic creation and deletion")
+
+	log.Println("Parsing arguments...")
+	flag.Parse()
+
+	var brokerCount int 
+	var brokerHostList [] string
+	var topicList [] string
+	
+	brokerHostList = strings.Split(brokerHosts,",")
+	topicList = strings.Split(topics,",")
+	brokerCount = len(brokerHostList)
+	
+    log.Println("Total brokers " + strconv.Itoa(brokerCount))
+ 
+ 	http.DefaultServeMux = http.NewServeMux()
+
+ 	//Limiting max broker to 5 and 1 zookeepercluster
+ 	var brokerUpdatesList [6]chan  check.Update
+ 	var healthCheckList [6] *check.HealthCheck
+
+ 	clusterUpdates := make(chan check.Update, 2)
+
+ 	
+ 	stop, awaitCheck := addShutdownHook()
+
+ 	
+	for i := 0 ; i <brokerCount; i++ {
+		healthCheckList[i] = check.New(checkConfiguration)
+		healthCheckList[i].ParseCommandLineArguments(brokerHostList[i],uint(i),brokerPort,statusServerPort,zookeeperConnect,topicList[i],replicationTopicName,replicationFailureThreshold,CheckInterval,NoTopicCreation)
+		brokerUpdatesList[i] = make(chan check.Update, 2)
+		healthCheckList[i].ServeHealth(brokerUpdatesList[i], stop,strconv.Itoa(i))
+	}
+	
+	healthCheckList[brokerCount].ServeHealthCluster(clusterUpdates,stop) // for zookeepercluster 
+
+	
+	go startHttpServer(statusServerPort,stop)
+	
+	connectionInterval := 5*time.Second
+	ticker := time.NewTicker(connectionInterval)
+	allConnected := true
+	for {
+		select {
+			case <-ticker.C:
+				allConnected = true
+				for i :=0;i <brokerCount ; i++{
+					log.Println("Initializing broker number " + strconv.Itoa(i))
+					connected := healthCheckList[i].InitializeConnection(stop)
+					allConnected = allConnected && connected
+				}
+			case <- stop:
+				ticker.Stop()
+				return
+			}
+
+		if allConnected{
+			ticker.Stop()
+			break
+		}
+	}
+
+	doloop := true
+
+	ticker = time.NewTicker(CheckInterval)
+	log.Println("Starting HealthCheck..... ")
+
+	for{
+
+		select {
+			case <-stop:
+				doloop = false
+				ticker.Stop()
+			case <-ticker.C:
+				for i :=0;i <brokerCount ; i++{
+					log.Println("checking broker number " + strconv.Itoa(i))
+					healthCheckList[i].CheckHealth(brokerUpdatesList[i], clusterUpdates, stop)
+				}
+				continue
+			}
+
+			if !doloop{
+				break
+			}
+	}
+
+ 	awaitCheck.Done()
+	log.Println("healthcheck ENDED...")
+	
+}
+
+
+func startHttpServer(statusServerPort uint,stop <-chan struct{}){
+	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", statusServerPort))
+	if err != nil {
+		log.Fatal("Unable to listen to port ", statusServerPort, ": ", err)
+	}
+
+	go func() {
+		for {
+			select {
+			case <-stop:
+				listener.Close()
+				log.Println("listener closed....")
+				return
+			}
+		}
+	}()
+	http.Serve(listener, nil)
+	return 
 }
 
 func addShutdownHook() (chan struct{}, *sync.WaitGroup) {
@@ -40,7 +169,7 @@ func addShutdownHook() (chan struct{}, *sync.WaitGroup) {
 }
 
 var checkConfiguration = check.HealthCheckConfig{
-	CheckTimeout:     200 * time.Millisecond,
+	CheckTimeout:     100 * time.Millisecond,
 	DataWaitInterval: 20 * time.Millisecond,
 	MessageLength:    20,
 }


### PR DESCRIPTION
In case , kafka-health-check is being run on a single machine and it needs to do health check on multiple brokers. This fork takes multiple broker ips separated comma and loops to do a health check on all of them.