### PR TITLE
Update Sirupsen/logrus repository name

### DIFF
--- a/check/broker_health_check.go
+++ b/check/broker_health_check.go
@@ -4,9 +4,9 @@ import (
 	"math/rand"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/optiopay/kafka"
 	"github.com/optiopay/kafka/proto"
+	log "github.com/sirupsen/logrus"
 )
 
 // sends one message to the broker partition, wait for it to appear on the consumer.

--- a/check/health_check.go
+++ b/check/health_check.go
@@ -4,8 +4,8 @@ import (
 	"math/rand"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/optiopay/kafka"
+	log "github.com/sirupsen/logrus"
 )
 
 // HealthCheck holds all data required for health checking.

--- a/check/parse_args.go
+++ b/check/parse_args.go
@@ -8,7 +8,7 @@ import (
 	"regexp"
 	"time"
 
-	logr "github.com/Sirupsen/logrus"
+	logr "github.com/sirupsen/logrus"
 )
 
 // ParseCommandLineArguments parses the command line arguments.

--- a/check/setup.go
+++ b/check/setup.go
@@ -5,10 +5,10 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/optiopay/kafka/proto"
 	"github.com/pkg/errors"
 	"github.com/samuel/go-zookeeper/zk"
+	log "github.com/sirupsen/logrus"
 )
 
 func (check *HealthCheck) connect(firstConnection bool, stop <-chan struct{}) error {

--- a/check/status_server.go
+++ b/check/status_server.go
@@ -7,7 +7,7 @@ import (
 	"net"
 	"net/http"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 // ServeHealth answers http queries for broker and cluster health.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,12 +3,6 @@
 	"ignore": "test",
 	"package": [
 		{
-			"checksumSHA1": "2avCvSn0XonfApKKuTMyiQmk7s0=",
-			"path": "github.com/Sirupsen/logrus",
-			"revision": "3ec0642a7fb6488f65b06f9040adc67e3990296a",
-			"revisionTime": "2016-08-29T20:23:21Z"
-		},
-		{
 			"checksumSHA1": "JSHl8b3nI8EWvzm+uyrIqj2Hiu4=",
 			"path": "github.com/golang/mock/gomock",
 			"revision": "bd3c8e81be01eef76d4b503f5e687d2d1354d2d9"
@@ -53,6 +47,12 @@
 			"checksumSHA1": "Mjz0ZUqS94MA3AjF7ros5I/RSxc=",
 			"path": "github.com/samuel/go-zookeeper/zk",
 			"revision": "5250732bd2ed71d1e374212ebfc32760eca10c0a"
+		},
+		{
+			"checksumSHA1": "ZOVI3VXoNknVPeRm8u+/hdf+XGA=",
+			"path": "github.com/sirupsen/logrus",
+			"revision": "3ec0642a7fb6488f65b06f9040adc67e3990296a",
+			"revisionTime": "2016-08-29T20:23:21Z"
 		},
 		{
 			"checksumSHA1": "noiZtKqeCoHgwUw9PQz4O3w3CnU=",


### PR DESCRIPTION
`Sirupsen` has changed his profile name to all lowercase. This will cause problems for `govendor` in some situations: https://github.com/kardianos/govendor/issues/347

This PR just updates all the import paths to use the new name.