### PR TITLE
Fix bug in delAll()

### DIFF
--- a/check/health_check.go
+++ b/check/health_check.go
@@ -112,7 +112,7 @@ func (check *HealthCheck) CheckHealth(brokerUpdates chan<- Update, clusterUpdate
 func newUpdate(report StatusReport, name string) Update {
 	data, err := report.Json()
 	if err != nil {
-		log.Warn("Error while marshaling %s status: %s", name, err.Error())
+		log.Warnf("Error while marshaling %s status: %s", name, err.Error())
 		data = simpleStatus(report.Summary())
 	}
 	return Update{report.Summary(), data}

--- a/check/int32_slice.go
+++ b/check/int32_slice.go
@@ -25,7 +25,7 @@ func delAt(a []int32, i int) []int32 {
 }
 
 func delAll(a []int32, el int32) []int32 {
-	for i, ok := indexOf(a, el); ok; {
+	for i, ok := indexOf(a, el); ok; i, ok = indexOf(a, el) {
 		a = delAt(a, i)
 	}
 	return a

--- a/check/int32_slice.go
+++ b/check/int32_slice.go
@@ -9,24 +9,11 @@ func contains(a []int32, el int32) bool {
 	return false
 }
 
-func indexOf(a []int32, el int32) (int, bool) {
-	for i, e := range a {
-		if e == el {
-			return i, true
+func delAll(a []int32, el int32) (ret []int32) {
+	for _, ael := range a {
+		if ael != el {
+			ret = append(ret, ael)
 		}
 	}
-	return -1, false
-}
-
-func delAt(a []int32, i int) []int32 {
-	copy(a[i:], a[i+1:])
-	a[len(a)-1] = 0
-	return a[:len(a)-1]
-}
-
-func delAll(a []int32, el int32) []int32 {
-	for i, ok := indexOf(a, el); ok; i, ok = indexOf(a, el) {
-		a = delAt(a, i)
-	}
-	return a
+	return
 }

--- a/check/int32_slice_test.go
+++ b/check/int32_slice_test.go
@@ -1,0 +1,76 @@
+package check
+
+import (
+	"reflect"
+	"testing"
+)
+
+// contains() tests
+
+func Test_Contains_ReturnsFalse(t *testing.T) {
+	if contains([]int32{1, 2, 3}, 4) == true {
+		t.Error()
+	}
+}
+
+func Test_Contains_ReturnsTrue(t *testing.T) {
+	if contains([]int32{1, 2, 3}, 2) == false {
+		t.Error()
+	}
+}
+
+// indexOf() tests
+
+func Test_IndexOf_ValueExists(t *testing.T) {
+	i, result := indexOf([]int32{1, 2, 3}, 2)
+	if i != 1 || result != true {
+		t.Error()
+	}
+}
+
+func Test_IndexOf_ValueDoesntExists(t *testing.T) {
+	i, result := indexOf([]int32{1, 2, 3}, 4)
+	if i != -1 || result != false {
+		t.Error()
+	}
+}
+
+// delAt() tests
+
+func Test_DelAt_ValueExists(t *testing.T) {
+	if !reflect.DeepEqual(delAt([]int32{1, 2, 3}, 1), []int32{1, 3}) {
+		t.Error()
+	}
+}
+
+// delAll() tests
+
+func Test_DelAll_Single(t *testing.T) {
+	if !reflect.DeepEqual(delAll([]int32{1, 2, 3}, 2), []int32{1, 3}) {
+		t.Error()
+	}
+}
+
+func Test_DelAll_Multiple(t *testing.T) {
+	if !reflect.DeepEqual(delAll([]int32{1, 2, 3, 2}, 2), []int32{1, 3}) {
+		t.Error()
+	}
+}
+
+func Test_DelAll_Missing(t *testing.T) {
+	if !reflect.DeepEqual(delAll([]int32{1, 2, 3}, 4), []int32{1, 2, 3}) {
+		t.Error()
+	}
+}
+
+func Test_DelAll_Front(t *testing.T) {
+	if !reflect.DeepEqual(delAll([]int32{1, 2, 3}, 1), []int32{2, 3}) {
+		t.Error()
+	}
+}
+
+func Test_DelAll_Back(t *testing.T) {
+	if !reflect.DeepEqual(delAll([]int32{1, 2, 3}, 3), []int32{1, 2}) {
+		t.Error()
+	}
+}

--- a/check/int32_slice_test.go
+++ b/check/int32_slice_test.go
@@ -19,30 +19,6 @@ func Test_Contains_ReturnsTrue(t *testing.T) {
 	}
 }
 
-// indexOf() tests
-
-func Test_IndexOf_ValueExists(t *testing.T) {
-	i, result := indexOf([]int32{1, 2, 3}, 2)
-	if i != 1 || result != true {
-		t.Error()
-	}
-}
-
-func Test_IndexOf_ValueDoesntExists(t *testing.T) {
-	i, result := indexOf([]int32{1, 2, 3}, 4)
-	if i != -1 || result != false {
-		t.Error()
-	}
-}
-
-// delAt() tests
-
-func Test_DelAt_ValueExists(t *testing.T) {
-	if !reflect.DeepEqual(delAt([]int32{1, 2, 3}, 1), []int32{1, 3}) {
-		t.Error()
-	}
-}
-
 // delAll() tests
 
 func Test_DelAll_Single(t *testing.T) {


### PR DESCRIPTION
Before this change, a SIGTERM resulted in the following:
```
panic: runtime error: slice bounds out of range

goroutine 1 [running]:
github.com/andreas-schroeder/kafka-health-check/check.delAt(0xc000018630, 0x6, 0x9, 0x6, 0xc000018630, 0x6, 0x9)
	/go/src/github.com/andreas-schroeder/kafka-health-check/check/int32_slice.go:27 +0x1f3
github.com/andreas-schroeder/kafka-health-check/check.delAll(0xc000018630, 0x8, 0x9, 0xc000000007, 0x1, 0xc0001aaa10, 0x6)
	/go/src/github.com/andreas-schroeder/kafka-health-check/check/int32_slice.go:35 +0x187
github.com/andreas-schroeder/kafka-health-check/check.(*HealthCheck).deleteTopic(0xc0000f0000, 0x798420, 0xc00000e040, 0xc0001aaa10, 0x6, 0x748196, 0x18, 0x0, 0x0, 0x0)
	/go/src/github.com/andreas-schroeder/kafka-health-check/check/setup.go:315 +0x31e
github.com/andreas-schroeder/kafka-health-check/check.(*HealthCheck).closeConnection(0xc0000f0000, 0x1)
	/go/src/github.com/andreas-schroeder/kafka-health-check/check/setup.go:294 +0x253
github.com/andreas-schroeder/kafka-health-check/check.(*HealthCheck).CheckHealth(0xc0000f0000, 0xc000128000, 0xc000128060, 0xc00001e180)
	/go/src/github.com/andreas-schroeder/kafka-health-check/check/health_check.go:107 +0x7f0
main.main()
	/go/src/github.com/andreas-schroeder/kafka-health-check/main.go:20 +0x150
```


This change fixes the bug on line 28 of check/int32_slice.go and adds tests.